### PR TITLE
Fix Bug in HaarWaveletTransform3D, Added correct output packing with k=8

### DIFF
--- a/causalvideovae/model/modules/wavelet.py
+++ b/causalvideovae/model/modules/wavelet.py
@@ -5,9 +5,6 @@ from ..modules import CausalConv3d
 from ..modules.ops import video_to_image
 
 from einops import rearrange
-
-def conv():
-            return nn.Conv3d(1, 1, kernel_size=2, stride=2, padding=0, bias=False)
         
 class HaarWaveletTransform3D(nn.Module):
     def __init__(self, *args, **kwargs) -> None:

--- a/causalvideovae/model/modules/wavelet.py
+++ b/causalvideovae/model/modules/wavelet.py
@@ -6,6 +6,9 @@ from ..modules.ops import video_to_image
 
 from einops import rearrange
 
+def conv():
+            return nn.Conv3d(1, 1, kernel_size=2, stride=2, padding=0, bias=False)
+        
 class HaarWaveletTransform3D(nn.Module):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -77,7 +80,7 @@ class HaarWaveletTransform3D(nn.Module):
             outputs.append(self.gh_v_conv(y))
         
         outputs = torch.cat(outputs, dim=0)
-        outputs = rearrange(outputs, "(b k c) 1 t h w -> b (c k) t h w", b=b, c=c, k=8)
+        outputs = rearrange(outputs, "(b c k) 1 t h w -> b (k c) t h w", b=b, c=c, k=8)
         return outputs
     
 class InverseHaarWaveletTransform3D(nn.Module):

--- a/causalvideovae/model/modules/wavelet.py
+++ b/causalvideovae/model/modules/wavelet.py
@@ -77,7 +77,7 @@ class HaarWaveletTransform3D(nn.Module):
             outputs.append(self.gh_v_conv(y))
         
         outputs = torch.cat(outputs, dim=0)
-        outputs = rearrange(outputs, "(b k c) 1 t h w -> b (c k) t h w", b=b, k=c)
+        outputs = rearrange(outputs, "(b k c) 1 t h w -> b (c k) t h w", b=b, c=c, k=8)
         return outputs
     
 class InverseHaarWaveletTransform3D(nn.Module):


### PR DESCRIPTION
The final einops.rearrange in HaarWaveletTransform3D.forward incorrectly used k=c, which is only true when C==8. Even though it seems like it works I am guessing because we have just specified incorrect k, so it compensates the rest with c. The first dimension of the stacked outputs is 8*(B*C), so the proper factorization is (b k c) with k=8.